### PR TITLE
Update interfaces.py

### DIFF
--- a/src/isu/onece/interfaces.py
+++ b/src/isu/onece/interfaces.py
@@ -135,6 +135,21 @@ class IFlowDocument(IDocument):
         required=True
         # readonly = true # ? FIXME: Determinate!
     )
+    
+    total = zope.schema.Float(
+        title=_("total"),
+        description=_(
+            "Determinates sum of the document"),
+        required=True
+    )
+    
+    counter = zope.schema.Object(
+        title=_("Conter"),
+        description=_("Determinates another party in the transaction"),
+        required=True
+    )
+    
+    
 
 
 class IRecordEvent(zope.interface.interfaces.IObjectEvent):


### PR DESCRIPTION
У документа прихода или расхода в любом случаи будет сумма, поэтому добавил в IFlowDocument атрибут total. 
Раз у нас есть атрибут receipt, который определяет приход это расход, то нам не нужно делать отдельных атрибутов получатель и отправитель а можно использовать атрибут counter, который в зависимости от значения receipt, становится получающей или отправляющей стороной